### PR TITLE
[Feat/224] 오늘의 웨디 카드값 마진 오류 수정

### DIFF
--- a/Weathy/Weathy/Resources/Storyboards/Main/Main.storyboard
+++ b/Weathy/Weathy/Resources/Storyboards/Main/Main.storyboard
@@ -159,32 +159,36 @@
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yen-xK-7Fn">
                                                                         <rect key="frame" x="33" y="282" width="309" height="268"/>
                                                                         <subviews>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jtX-aA-2Ev" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="26" y="21" width="0.0" height="0.0"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dddd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jtX-aA-2Ev" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="26.000000000000004" y="21" width="40.333333333333343" height="17"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="17" id="CGA-wy-ves"/>
+                                                                                </constraints>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="yPj-Yg-4pD">
-                                                                                <rect key="frame" x="26" y="25" width="20" height="20"/>
+                                                                                <rect key="frame" x="26" y="42" width="20" height="20"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="width" secondItem="yPj-Yg-4pD" secondAttribute="height" multiplier="1:1" id="T0b-5g-ODV"/>
+                                                                                    <constraint firstAttribute="width" constant="20" id="rtM-CZ-3qv"/>
                                                                                 </constraints>
                                                                             </imageView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o2I-jh-22a" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="52" y="25.333333333333314" width="0.0" height="19"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dddd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o2I-jh-22a" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="52" y="41.666666666666686" width="40.333333333333343" height="20.333333333333329"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8M6-kI-Ehi" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="26" y="55" width="0.0" height="0.0"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dddd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8M6-kI-Ehi" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="26.000000000000004" y="72" width="40.333333333333343" height="20.333333333333329"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aHY-MB-qSB" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="38" y="55" width="0.0" height="0.0"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dddd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aHY-MB-qSB" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="79.333333333333329" y="72" width="40.333333333333329" height="20.333333333333329"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -195,14 +199,17 @@
                                                                                     <constraint firstAttribute="width" secondItem="KfE-aB-E0j" secondAttribute="height" multiplier="1:1" id="Isa-Au-w41"/>
                                                                                 </constraints>
                                                                             </imageView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2l3-JL-ALc" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="283" y="55" width="0.0" height="0.0"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ddddd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2l3-JL-ALc" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="232.66666666666671" y="72" width="50.333333333333343" height="20.333333333333329"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="상의" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uso-P0-V35" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="26" y="98" width="22.666666666666671" height="16"/>
+                                                                                <rect key="frame" x="26" y="147" width="22.666666666666671" height="17"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="17" id="0fo-YR-8Aj"/>
+                                                                                </constraints>
                                                                                 <fontDescription key="fontDescription" name="AppleSDGothicNeoR00" family="AppleSDGothicNeoR00" pointSize="13"/>
                                                                                 <color key="textColor" red="0.57647058819999997" green="0.57647058819999997" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -213,7 +220,10 @@
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="하의" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YRs-tg-j5a" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="26" y="124" width="22.666666666666671" height="16"/>
+                                                                                <rect key="frame" x="26" y="174" width="22.666666666666671" height="17"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="17" id="sLw-X7-Gjw"/>
+                                                                                </constraints>
                                                                                 <fontDescription key="fontDescription" name="AppleSDGothicNeoR00" family="AppleSDGothicNeoR00" pointSize="13"/>
                                                                                 <color key="textColor" red="0.57647058819999997" green="0.57647058819999997" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -224,7 +234,10 @@
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="외투" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pok-C8-ljn" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="26" y="150" width="22.666666666666671" height="16"/>
+                                                                                <rect key="frame" x="26" y="201" width="22.666666666666671" height="17"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="17" id="xaX-4e-jd6"/>
+                                                                                </constraints>
                                                                                 <fontDescription key="fontDescription" name="AppleSDGothicNeoR00" family="AppleSDGothicNeoR00" pointSize="13"/>
                                                                                 <color key="textColor" red="0.57647058819999997" green="0.57647058819999997" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -235,7 +248,10 @@
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="기타" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gGA-Yk-EEO" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="26" y="176" width="22.666666666666671" height="16"/>
+                                                                                <rect key="frame" x="26" y="228" width="22.666666666666671" height="17"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="17" id="hCc-rq-Kk2"/>
+                                                                                </constraints>
                                                                                 <fontDescription key="fontDescription" name="AppleSDGothicNeoR00" family="AppleSDGothicNeoR00" pointSize="13"/>
                                                                                 <color key="textColor" red="0.57647058819999997" green="0.57647058819999997" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -246,13 +262,13 @@
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hjg-YJ-Zmu">
-                                                                                <rect key="frame" x="29" y="25.666666666666686" width="5" height="20.333333333333329"/>
+                                                                                <rect key="frame" x="69.333333333333329" y="72" width="5" height="20.333333333333329"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <color key="textColor" red="0.41960784309999999" green="0.41960784309999999" blue="0.41960784309999999" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="epg-t7-rhN" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="56.666666666666671" y="106" width="0.0" height="0.0"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dsfd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="epg-t7-rhN" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="56.666666666666671" y="145.33333333333337" width="34" height="20.333333333333343"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -262,8 +278,8 @@
                                                                                     </userDefinedRuntimeAttribute>
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hy6-8V-qma" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="56.666666666666671" y="132" width="0.0" height="0.0"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="sdfsdf" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hy6-8V-qma" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="56.666666666666671" y="172.33333333333337" width="48" height="20.333333333333343"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -273,8 +289,8 @@
                                                                                     </userDefinedRuntimeAttribute>
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YwU-bh-amp" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="56.666666666666671" y="158" width="0.0" height="0.0"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="sf" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YwU-bh-amp" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="56.666666666666671" y="199.33333333333337" width="14.333333333333329" height="20.333333333333343"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -284,8 +300,8 @@
                                                                                     </userDefinedRuntimeAttribute>
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUX-6u-7bn" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="56.666666666666671" y="184" width="0.0" height="0.0"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="sdfsdf" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUX-6u-7bn" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="56.666666666666671" y="226.33333333333337" width="48" height="20.333333333333343"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -296,7 +312,7 @@
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Arf-xW-AEJ">
-                                                                                <rect key="frame" x="235" y="66" width="48" height="20"/>
+                                                                                <rect key="frame" x="235" y="103.33333333333331" width="48" height="20"/>
                                                                                 <subviews>
                                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="mainIcImage" translatesAutoresizingMaskIntoConstraints="NO" id="ehg-Rn-0qb">
                                                                                         <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
@@ -314,12 +330,6 @@
                                                                                     <constraint firstAttribute="trailing" secondItem="dn3-sZ-lLU" secondAttribute="trailing" id="Qfi-bA-Hnl"/>
                                                                                 </constraints>
                                                                             </stackView>
-                                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5F4-qv-YB2">
-                                                                                <rect key="frame" x="13" y="13" width="283" height="242"/>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="width" secondItem="5F4-qv-YB2" secondAttribute="height" multiplier="283:242" id="Pn1-IJ-LnP"/>
-                                                                                </constraints>
-                                                                            </imageView>
                                                                         </subviews>
                                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <constraints>
@@ -327,41 +337,37 @@
                                                                             <constraint firstItem="epg-t7-rhN" firstAttribute="leading" secondItem="uso-P0-V35" secondAttribute="trailing" constant="8" id="19w-BE-2oh"/>
                                                                             <constraint firstItem="Arf-xW-AEJ" firstAttribute="height" secondItem="Yen-xK-7Fn" secondAttribute="height" multiplier="20:268" id="1yT-Hv-2zM"/>
                                                                             <constraint firstItem="ZUX-6u-7bn" firstAttribute="centerY" secondItem="gGA-Yk-EEO" secondAttribute="centerY" id="5GW-fY-p4G"/>
+                                                                            <constraint firstItem="2l3-JL-ALc" firstAttribute="bottom" secondItem="aHY-MB-qSB" secondAttribute="bottom" id="5OW-1T-x3E"/>
                                                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ZUX-6u-7bn" secondAttribute="trailing" constant="26" id="9QS-kM-Kxf"/>
                                                                             <constraint firstItem="gGA-Yk-EEO" firstAttribute="top" secondItem="Pok-C8-ljn" secondAttribute="bottom" constant="10" id="ALN-BN-l24"/>
                                                                             <constraint firstItem="uso-P0-V35" firstAttribute="leading" secondItem="yPj-Yg-4pD" secondAttribute="leading" id="B6v-cw-6wM"/>
                                                                             <constraint firstItem="jtX-aA-2Ev" firstAttribute="top" secondItem="Yen-xK-7Fn" secondAttribute="top" constant="21" id="BJ3-R6-mem"/>
                                                                             <constraint firstAttribute="width" secondItem="Yen-xK-7Fn" secondAttribute="height" multiplier="309:268" id="Bpm-ET-OKU"/>
                                                                             <constraint firstItem="YRs-tg-j5a" firstAttribute="leading" secondItem="uso-P0-V35" secondAttribute="leading" id="ChS-mH-IT1"/>
-                                                                            <constraint firstItem="Hjg-YJ-Zmu" firstAttribute="bottom" secondItem="8M6-kI-Ehi" secondAttribute="bottom" constant="-9" id="EHg-2O-LGo"/>
-                                                                            <constraint firstItem="5F4-qv-YB2" firstAttribute="centerY" secondItem="Yen-xK-7Fn" secondAttribute="centerY" id="Fak-DR-0L3"/>
+                                                                            <constraint firstAttribute="bottom" secondItem="gGA-Yk-EEO" secondAttribute="bottom" constant="23" id="DmM-n1-zwz"/>
                                                                             <constraint firstItem="KfE-aB-E0j" firstAttribute="width" secondItem="Yen-xK-7Fn" secondAttribute="width" multiplier="42:309" id="G1c-OS-P6U"/>
                                                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YwU-bh-amp" secondAttribute="trailing" constant="26" id="Hoj-Ki-kQu"/>
-                                                                            <constraint firstItem="o2I-jh-22a" firstAttribute="height" secondItem="yPj-Yg-4pD" secondAttribute="height" multiplier="0.954545" id="Jgn-h5-Aog"/>
-                                                                            <constraint firstItem="5F4-qv-YB2" firstAttribute="centerX" secondItem="Yen-xK-7Fn" secondAttribute="centerX" id="Joj-aB-zUl"/>
-                                                                            <constraint firstItem="uso-P0-V35" firstAttribute="top" secondItem="Arf-xW-AEJ" secondAttribute="bottom" constant="12" id="KG6-Vj-l6M"/>
+                                                                            <constraint firstItem="uso-P0-V35" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Arf-xW-AEJ" secondAttribute="bottom" constant="12" id="KG6-Vj-l6M"/>
                                                                             <constraint firstItem="Hy6-8V-qma" firstAttribute="centerY" secondItem="YRs-tg-j5a" secondAttribute="centerY" id="L6m-Jb-bUl"/>
                                                                             <constraint firstItem="YwU-bh-amp" firstAttribute="leading" secondItem="Pok-C8-ljn" secondAttribute="trailing" constant="8" id="M0Q-fG-uFt"/>
-                                                                            <constraint firstItem="aHY-MB-qSB" firstAttribute="leading" secondItem="Hjg-YJ-Zmu" secondAttribute="trailing" constant="4" id="Ozh-W4-FhZ"/>
+                                                                            <constraint firstItem="aHY-MB-qSB" firstAttribute="leading" secondItem="Hjg-YJ-Zmu" secondAttribute="trailing" constant="5" id="Ozh-W4-FhZ"/>
                                                                             <constraint firstItem="o2I-jh-22a" firstAttribute="leading" secondItem="yPj-Yg-4pD" secondAttribute="trailing" constant="6" id="POT-L5-TwN"/>
                                                                             <constraint firstItem="ZUX-6u-7bn" firstAttribute="leading" secondItem="gGA-Yk-EEO" secondAttribute="trailing" constant="8" id="R7H-4p-sto"/>
                                                                             <constraint firstItem="yPj-Yg-4pD" firstAttribute="leading" secondItem="jtX-aA-2Ev" secondAttribute="leading" id="RJF-pB-GM2"/>
                                                                             <constraint firstItem="2l3-JL-ALc" firstAttribute="trailing" secondItem="KfE-aB-E0j" secondAttribute="trailing" id="U8c-ol-yUM"/>
-                                                                            <constraint firstItem="aHY-MB-qSB" firstAttribute="centerY" secondItem="8M6-kI-Ehi" secondAttribute="centerY" id="V9z-Gi-acI"/>
                                                                             <constraint firstItem="jtX-aA-2Ev" firstAttribute="leading" secondItem="Yen-xK-7Fn" secondAttribute="leading" constant="26" id="WFh-Kb-ekn"/>
+                                                                            <constraint firstItem="aHY-MB-qSB" firstAttribute="bottom" secondItem="8M6-kI-Ehi" secondAttribute="bottom" id="WGf-g4-chx"/>
                                                                             <constraint firstItem="gGA-Yk-EEO" firstAttribute="leading" secondItem="Pok-C8-ljn" secondAttribute="leading" id="WfW-5a-60f"/>
                                                                             <constraint firstItem="Arf-xW-AEJ" firstAttribute="trailing" secondItem="KfE-aB-E0j" secondAttribute="trailing" id="a2W-0L-r6Z"/>
-                                                                            <constraint firstItem="5F4-qv-YB2" firstAttribute="width" secondItem="Yen-xK-7Fn" secondAttribute="width" multiplier="283:309" id="a8b-7c-YVc"/>
+                                                                            <constraint firstItem="aHY-MB-qSB" firstAttribute="top" secondItem="8M6-kI-Ehi" secondAttribute="top" id="aRt-ux-Fm4"/>
+                                                                            <constraint firstItem="o2I-jh-22a" firstAttribute="bottom" secondItem="yPj-Yg-4pD" secondAttribute="bottom" id="aY3-7F-iH6"/>
                                                                             <constraint firstItem="Pok-C8-ljn" firstAttribute="leading" secondItem="YRs-tg-j5a" secondAttribute="leading" id="b5d-Pa-4Hj"/>
-                                                                            <constraint firstItem="yPj-Yg-4pD" firstAttribute="width" secondItem="Yen-xK-7Fn" secondAttribute="width" multiplier="20:309" id="ctj-qi-3oz"/>
-                                                                            <constraint firstItem="o2I-jh-22a" firstAttribute="centerY" secondItem="yPj-Yg-4pD" secondAttribute="centerY" id="dBd-5S-6jL"/>
                                                                             <constraint firstItem="YRs-tg-j5a" firstAttribute="top" secondItem="uso-P0-V35" secondAttribute="bottom" constant="10" id="dtc-gN-RtP"/>
                                                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Hy6-8V-qma" secondAttribute="trailing" constant="26" id="exk-sn-EME"/>
                                                                             <constraint firstItem="Arf-xW-AEJ" firstAttribute="top" secondItem="2l3-JL-ALc" secondAttribute="bottom" constant="11" id="g7b-6O-246"/>
-                                                                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="gGA-Yk-EEO" secondAttribute="bottom" constant="23" id="hXF-So-V7G"/>
                                                                             <constraint firstAttribute="trailing" secondItem="KfE-aB-E0j" secondAttribute="trailing" constant="26" id="hZL-1l-snW"/>
+                                                                            <constraint firstItem="Hjg-YJ-Zmu" firstAttribute="centerY" secondItem="8M6-kI-Ehi" secondAttribute="centerY" id="j89-E5-Tlp"/>
                                                                             <constraint firstItem="Hy6-8V-qma" firstAttribute="leading" secondItem="YRs-tg-j5a" secondAttribute="trailing" constant="8" id="lMC-Vo-kij"/>
-                                                                            <constraint firstItem="2l3-JL-ALc" firstAttribute="top" secondItem="aHY-MB-qSB" secondAttribute="top" id="mzH-JG-bqd"/>
                                                                             <constraint firstItem="epg-t7-rhN" firstAttribute="centerY" secondItem="uso-P0-V35" secondAttribute="centerY" id="nXr-aI-nVf"/>
                                                                             <constraint firstItem="YwU-bh-amp" firstAttribute="centerY" secondItem="Pok-C8-ljn" secondAttribute="centerY" id="ndy-Ur-tyi"/>
                                                                             <constraint firstItem="KfE-aB-E0j" firstAttribute="top" secondItem="jtX-aA-2Ev" secondAttribute="top" id="pGM-ba-dtQ"/>
@@ -407,14 +413,22 @@
                                                             <constraint firstAttribute="trailing" secondItem="pWU-wR-04A" secondAttribute="trailing" id="vVR-qk-aEc"/>
                                                         </constraints>
                                                     </scrollView>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cQ9-yk-XNu">
+                                                        <rect key="frame" x="10" y="10" width="283" height="242"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" secondItem="cQ9-yk-XNu" secondAttribute="height" multiplier="283:242" id="HNu-LJ-96P"/>
+                                                        </constraints>
+                                                    </imageView>
                                                 </subviews>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstItem="CGJ-dH-q1z" firstAttribute="leading" secondItem="cCz-ny-pRZ" secondAttribute="leading" id="7M8-3I-8jD"/>
                                                     <constraint firstItem="CGJ-dH-q1z" firstAttribute="width" secondItem="cCz-ny-pRZ" secondAttribute="width" id="FLQ-d0-Pjh"/>
+                                                    <constraint firstItem="cQ9-yk-XNu" firstAttribute="width" secondItem="cQ9-yk-XNu" secondAttribute="height" multiplier="283:242" id="LjQ-FS-q6G"/>
                                                     <constraint firstItem="CGJ-dH-q1z" firstAttribute="top" secondItem="cCz-ny-pRZ" secondAttribute="top" id="dBZ-4y-eIc"/>
                                                     <constraint firstAttribute="height" constant="750" id="dDQ-Wo-hZq"/>
                                                     <constraint firstAttribute="bottom" secondItem="CGJ-dH-q1z" secondAttribute="bottom" id="e2a-D6-rmy"/>
+                                                    <constraint firstItem="cQ9-yk-XNu" firstAttribute="width" secondItem="cQ9-yk-XNu" secondAttribute="height" multiplier="283:242" id="hpm-IL-sH7"/>
                                                     <constraint firstAttribute="trailing" secondItem="CGJ-dH-q1z" secondAttribute="trailing" id="q4d-3W-cC3"/>
                                                     <constraint firstItem="CGJ-dH-q1z" firstAttribute="height" secondItem="cCz-ny-pRZ" secondAttribute="height" id="rdj-YR-K2u"/>
                                                 </constraints>
@@ -927,7 +941,7 @@
                         <outlet property="closetTopLabel" destination="epg-t7-rhN" id="fSF-WL-rgh"/>
                         <outlet property="currTempLabel" destination="L4V-RD-s5W" id="jxj-ze-8QM"/>
                         <outlet property="downImage" destination="EUK-lb-A1U" id="a5L-Nt-jWq"/>
-                        <outlet property="emptyImage" destination="5F4-qv-YB2" id="VUQ-eg-Jsn"/>
+                        <outlet property="emptyImage" destination="cQ9-yk-XNu" id="ycH-t3-ug8"/>
                         <outlet property="extraCenterY" destination="psE-d7-jVk" id="avv-zu-Lkl"/>
                         <outlet property="extraWeatherCollectionView" destination="EuQ-ft-IXf" id="qU4-PA-lnQ"/>
                         <outlet property="extraWeatherView" destination="wCR-QC-8t8" id="zWl-3q-LBE"/>

--- a/Weathy/Weathy/Resources/Storyboards/Main/Main.storyboard
+++ b/Weathy/Weathy/Resources/Storyboards/Main/Main.storyboard
@@ -159,8 +159,8 @@
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yen-xK-7Fn">
                                                                         <rect key="frame" x="33" y="282" width="309" height="268"/>
                                                                         <subviews>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dddd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jtX-aA-2Ev" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="26.000000000000004" y="21" width="40.333333333333343" height="17"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jtX-aA-2Ev" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="26" y="21" width="0.0" height="17"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="17" id="CGA-wy-ves"/>
                                                                                 </constraints>
@@ -175,20 +175,20 @@
                                                                                     <constraint firstAttribute="width" constant="20" id="rtM-CZ-3qv"/>
                                                                                 </constraints>
                                                                             </imageView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dddd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o2I-jh-22a" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="52" y="41.666666666666686" width="40.333333333333343" height="20.333333333333329"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o2I-jh-22a" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="52" y="62" width="0.0" height="0.0"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dddd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8M6-kI-Ehi" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="26.000000000000004" y="72" width="40.333333333333343" height="20.333333333333329"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8M6-kI-Ehi" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="26" y="72" width="0.0" height="0.0"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dddd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aHY-MB-qSB" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="79.333333333333329" y="72" width="40.333333333333329" height="20.333333333333329"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aHY-MB-qSB" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="39" y="72" width="0.0" height="0.0"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -199,8 +199,8 @@
                                                                                     <constraint firstAttribute="width" secondItem="KfE-aB-E0j" secondAttribute="height" multiplier="1:1" id="Isa-Au-w41"/>
                                                                                 </constraints>
                                                                             </imageView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ddddd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2l3-JL-ALc" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="232.66666666666671" y="72" width="50.333333333333343" height="20.333333333333329"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2l3-JL-ALc" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="283" y="72" width="0.0" height="0.0"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -262,13 +262,13 @@
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hjg-YJ-Zmu">
-                                                                                <rect key="frame" x="69.333333333333329" y="72" width="5" height="20.333333333333329"/>
+                                                                                <rect key="frame" x="29" y="61.666666666666693" width="5" height="20.333333333333336"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <color key="textColor" red="0.41960784309999999" green="0.41960784309999999" blue="0.41960784309999999" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dsfd" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="epg-t7-rhN" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="56.666666666666671" y="145.33333333333337" width="34" height="20.333333333333343"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="epg-t7-rhN" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="56.666666666666671" y="155.33333333333337" width="0.0" height="0.0"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -278,8 +278,8 @@
                                                                                     </userDefinedRuntimeAttribute>
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="sdfsdf" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hy6-8V-qma" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="56.666666666666671" y="172.33333333333337" width="48" height="20.333333333333343"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hy6-8V-qma" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="56.666666666666671" y="182.33333333333337" width="0.0" height="0.0"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -289,8 +289,8 @@
                                                                                     </userDefinedRuntimeAttribute>
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="sf" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YwU-bh-amp" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="56.666666666666671" y="199.33333333333337" width="14.333333333333329" height="20.333333333333343"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YwU-bh-amp" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="56.666666666666671" y="209.33333333333337" width="0.0" height="0.0"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -300,8 +300,8 @@
                                                                                     </userDefinedRuntimeAttribute>
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="sdfsdf" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUX-6u-7bn" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
-                                                                                <rect key="frame" x="56.666666666666671" y="226.33333333333337" width="48" height="20.333333333333343"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUX-6u-7bn" customClass="SpacedLabel" customModule="Weathy" customModuleProvider="target">
+                                                                                <rect key="frame" x="56.666666666666671" y="236.33333333333337" width="0.0" height="0.0"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -312,7 +312,7 @@
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Arf-xW-AEJ">
-                                                                                <rect key="frame" x="235" y="103.33333333333331" width="48" height="20"/>
+                                                                                <rect key="frame" x="235" y="83" width="48" height="20"/>
                                                                                 <subviews>
                                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="mainIcImage" translatesAutoresizingMaskIntoConstraints="NO" id="ehg-Rn-0qb">
                                                                                         <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>

--- a/Weathy/Weathy/Resources/Storyboards/Main/Main.storyboard
+++ b/Weathy/Weathy/Resources/Storyboards/Main/Main.storyboard
@@ -330,6 +330,12 @@
                                                                                     <constraint firstAttribute="trailing" secondItem="dn3-sZ-lLU" secondAttribute="trailing" id="Qfi-bA-Hnl"/>
                                                                                 </constraints>
                                                                             </stackView>
+                                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NYh-r6-WzY">
+                                                                                <rect key="frame" x="13" y="13" width="283" height="242"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="width" secondItem="NYh-r6-WzY" secondAttribute="height" multiplier="283:242" id="V6B-WT-LsI"/>
+                                                                                </constraints>
+                                                                            </imageView>
                                                                         </subviews>
                                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <constraints>
@@ -349,6 +355,7 @@
                                                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YwU-bh-amp" secondAttribute="trailing" constant="26" id="Hoj-Ki-kQu"/>
                                                                             <constraint firstItem="uso-P0-V35" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Arf-xW-AEJ" secondAttribute="bottom" constant="12" id="KG6-Vj-l6M"/>
                                                                             <constraint firstItem="Hy6-8V-qma" firstAttribute="centerY" secondItem="YRs-tg-j5a" secondAttribute="centerY" id="L6m-Jb-bUl"/>
+                                                                            <constraint firstItem="NYh-r6-WzY" firstAttribute="centerX" secondItem="Yen-xK-7Fn" secondAttribute="centerX" id="LvH-Ya-K8a"/>
                                                                             <constraint firstItem="YwU-bh-amp" firstAttribute="leading" secondItem="Pok-C8-ljn" secondAttribute="trailing" constant="8" id="M0Q-fG-uFt"/>
                                                                             <constraint firstItem="aHY-MB-qSB" firstAttribute="leading" secondItem="Hjg-YJ-Zmu" secondAttribute="trailing" constant="5" id="Ozh-W4-FhZ"/>
                                                                             <constraint firstItem="o2I-jh-22a" firstAttribute="leading" secondItem="yPj-Yg-4pD" secondAttribute="trailing" constant="6" id="POT-L5-TwN"/>
@@ -367,12 +374,14 @@
                                                                             <constraint firstItem="Arf-xW-AEJ" firstAttribute="top" secondItem="2l3-JL-ALc" secondAttribute="bottom" constant="11" id="g7b-6O-246"/>
                                                                             <constraint firstAttribute="trailing" secondItem="KfE-aB-E0j" secondAttribute="trailing" constant="26" id="hZL-1l-snW"/>
                                                                             <constraint firstItem="Hjg-YJ-Zmu" firstAttribute="centerY" secondItem="8M6-kI-Ehi" secondAttribute="centerY" id="j89-E5-Tlp"/>
+                                                                            <constraint firstItem="NYh-r6-WzY" firstAttribute="centerY" secondItem="Yen-xK-7Fn" secondAttribute="centerY" id="k3F-Hu-lKL"/>
                                                                             <constraint firstItem="Hy6-8V-qma" firstAttribute="leading" secondItem="YRs-tg-j5a" secondAttribute="trailing" constant="8" id="lMC-Vo-kij"/>
                                                                             <constraint firstItem="epg-t7-rhN" firstAttribute="centerY" secondItem="uso-P0-V35" secondAttribute="centerY" id="nXr-aI-nVf"/>
                                                                             <constraint firstItem="YwU-bh-amp" firstAttribute="centerY" secondItem="Pok-C8-ljn" secondAttribute="centerY" id="ndy-Ur-tyi"/>
                                                                             <constraint firstItem="KfE-aB-E0j" firstAttribute="top" secondItem="jtX-aA-2Ev" secondAttribute="top" id="pGM-ba-dtQ"/>
                                                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="epg-t7-rhN" secondAttribute="trailing" constant="26" id="qFv-0f-xUv"/>
                                                                             <constraint firstItem="Hjg-YJ-Zmu" firstAttribute="leading" secondItem="8M6-kI-Ehi" secondAttribute="trailing" constant="3" id="qY2-hu-A2G"/>
+                                                                            <constraint firstItem="NYh-r6-WzY" firstAttribute="width" secondItem="Yen-xK-7Fn" secondAttribute="width" multiplier="283:309" id="u1z-cH-tL7"/>
                                                                             <constraint firstItem="yPj-Yg-4pD" firstAttribute="top" secondItem="jtX-aA-2Ev" secondAttribute="bottom" constant="4" id="vLH-hy-NgY"/>
                                                                             <constraint firstItem="Pok-C8-ljn" firstAttribute="top" secondItem="YRs-tg-j5a" secondAttribute="bottom" constant="10" id="viY-jc-pP6"/>
                                                                             <constraint firstItem="8M6-kI-Ehi" firstAttribute="leading" secondItem="yPj-Yg-4pD" secondAttribute="leading" id="zg8-JI-EqL"/>
@@ -413,22 +422,14 @@
                                                             <constraint firstAttribute="trailing" secondItem="pWU-wR-04A" secondAttribute="trailing" id="vVR-qk-aEc"/>
                                                         </constraints>
                                                     </scrollView>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cQ9-yk-XNu">
-                                                        <rect key="frame" x="10" y="10" width="283" height="242"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" secondItem="cQ9-yk-XNu" secondAttribute="height" multiplier="283:242" id="HNu-LJ-96P"/>
-                                                        </constraints>
-                                                    </imageView>
                                                 </subviews>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstItem="CGJ-dH-q1z" firstAttribute="leading" secondItem="cCz-ny-pRZ" secondAttribute="leading" id="7M8-3I-8jD"/>
                                                     <constraint firstItem="CGJ-dH-q1z" firstAttribute="width" secondItem="cCz-ny-pRZ" secondAttribute="width" id="FLQ-d0-Pjh"/>
-                                                    <constraint firstItem="cQ9-yk-XNu" firstAttribute="width" secondItem="cQ9-yk-XNu" secondAttribute="height" multiplier="283:242" id="LjQ-FS-q6G"/>
                                                     <constraint firstItem="CGJ-dH-q1z" firstAttribute="top" secondItem="cCz-ny-pRZ" secondAttribute="top" id="dBZ-4y-eIc"/>
                                                     <constraint firstAttribute="height" constant="750" id="dDQ-Wo-hZq"/>
                                                     <constraint firstAttribute="bottom" secondItem="CGJ-dH-q1z" secondAttribute="bottom" id="e2a-D6-rmy"/>
-                                                    <constraint firstItem="cQ9-yk-XNu" firstAttribute="width" secondItem="cQ9-yk-XNu" secondAttribute="height" multiplier="283:242" id="hpm-IL-sH7"/>
                                                     <constraint firstAttribute="trailing" secondItem="CGJ-dH-q1z" secondAttribute="trailing" id="q4d-3W-cC3"/>
                                                     <constraint firstItem="CGJ-dH-q1z" firstAttribute="height" secondItem="cCz-ny-pRZ" secondAttribute="height" id="rdj-YR-K2u"/>
                                                 </constraints>
@@ -941,7 +942,7 @@
                         <outlet property="closetTopLabel" destination="epg-t7-rhN" id="fSF-WL-rgh"/>
                         <outlet property="currTempLabel" destination="L4V-RD-s5W" id="jxj-ze-8QM"/>
                         <outlet property="downImage" destination="EUK-lb-A1U" id="a5L-Nt-jWq"/>
-                        <outlet property="emptyImage" destination="cQ9-yk-XNu" id="ycH-t3-ug8"/>
+                        <outlet property="emptyImage" destination="NYh-r6-WzY" id="Wn3-V5-gKL"/>
                         <outlet property="extraCenterY" destination="psE-d7-jVk" id="avv-zu-Lkl"/>
                         <outlet property="extraWeatherCollectionView" destination="EuQ-ft-IXf" id="qU4-PA-lnQ"/>
                         <outlet property="extraWeatherView" destination="wCR-QC-8t8" id="zWl-3q-LBE"/>

--- a/Weathy/Weathy/Sources/VCs/Main/MainVC.swift
+++ b/Weathy/Weathy/Sources/VCs/Main/MainVC.swift
@@ -907,13 +907,13 @@ extension MainVC: UICollectionViewDelegate {
             let mainScrollContentOffset = mainScrollView.contentOffset.y
             let mainTopScrollContentOffset = mainTopScrollView.contentOffset.y
             
-            if (mainScrollContentOffset > 10 || mainTopScrollContentOffset > 10 ) {
+            if mainScrollContentOffset > 10 || mainTopScrollContentOffset > 10 {
                 UIView.animate(withDuration: 0.5) {
                     self.topBlurView.alpha = 1
                 }
             }
             
-            if (mainScrollContentOffset < 10 && mainTopScrollContentOffset < 10) {
+            if mainScrollContentOffset < 10 && mainTopScrollContentOffset < 10 {
                 UIView.animate(withDuration: 0.3) {
                     self.topBlurView.alpha = 0
                 }


### PR DESCRIPTION
## 🌈 PR 요약
카드값 마진값 동일하게 변경

## 📌 변경 사항
카드 상하좌우 마진을 동일하게 유지시키고
상의 - 사진, 글 아이콘 사이의 topAnchor를 greater or equal로 변경했습니다요. 

## 📸 ScreenShot
<img width="350" alt="스크린샷 2021-03-04 오후 11 54 07" src="https://user-images.githubusercontent.com/26399850/109982097-e9e0bd00-7d44-11eb-97e0-77baf9527846.png">

#### Linked Issue
close #224 

